### PR TITLE
Fix frontend container startup by installing react-scripts

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,13 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build"
-  }
+    "build": "react-scripts build",
+    "test": "react-scripts test",
+    "eject": "react-scripts eject"
+  },
+  "devDependencies": {
+    "react-scripts": "5.0.1"
+  },
+  "proxy": "http://localhost:8000"
 }
+


### PR DESCRIPTION
## Summary
- add dev dependency for `react-scripts`
- expose npm `test` and `eject` scripts
- configure proxy for local backend

`coin-parking-system-codex--frontend-1` failed because `react-scripts` was not installed. Adding the dependency fixes the missing command error.

## Testing
- `npm install` *(fails: 403 Forbidden, internet disabled)*

------
https://chatgpt.com/codex/tasks/task_e_6860ef7a051c8325b2913598ca6d3b7d